### PR TITLE
Do not force operator fingerprint if specified in the constructor

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -111,7 +111,10 @@ func NewManager(opts ManagerOptions) Manager {
 		failurePolicy := admissionregistrationv1beta1.Fail
 		opts.FailurePolicy = &failurePolicy
 	}
-	opts.OperatorFingerprint = "eirini-x"
+
+	if len(opts.OperatorFingerprint) == 0 {
+		opts.OperatorFingerprint = "eirini-x"
+	}
 
 	if len(opts.SetupCertificateName) == 0 {
 		opts.SetupCertificateName = opts.getSetupCertificateName()


### PR DESCRIPTION
This would force to create a new constructor to override the operator fingerprint - which is important in the case we want to run two operators on the same cluster in different locations e.g. different pods with different IPs. Otherwise it will try to consume the same cert