### PR TITLE
Respect RegisterWebHook also when generating configuration

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -104,4 +104,7 @@ type Manager interface {
 
 	// Helper to compute the patch from a pod update
 	PatchFromPod(req admission.Request, pod *corev1.Pod) admission.Response
+
+	// Register Extensions to the kubernetes cluster.
+	RegisterExtensions() error
 }

--- a/manager.go
+++ b/manager.go
@@ -356,8 +356,10 @@ func (m *DefaultExtensionManager) RegisterExtensions() error {
 		webhooks = append(webhooks, w)
 	}
 
-	if err := m.WebhookConfig.registerWebhooks(m.Context, webhooks); err != nil {
-		return errors.Wrap(err, "generating the webhook server configuration")
+	if m.Options.RegisterWebHook == nil || m.Options.RegisterWebHook != nil && *m.Options.RegisterWebHook {
+		if err := m.WebhookConfig.registerWebhooks(m.Context, webhooks); err != nil {
+			return errors.Wrap(err, "generating the webhook server configuration")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This was the last piece to limit the responsability of the code parts.
 
In this way extensions could be split in two binaries, one that creates
the MutatingWebhookConfiguration (which can be a job, or just a process that later on drop capabilities) and one that runs the service in a _no-cluster-admin_ context.

