### PR TITLE
Split registration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: go
 go:
   - "1.12"
+services:
+    - docker
 env:
   - GO111MODULE=on
 before_install:
   - make tools
 script:
-  - go test -coverprofile=coverage.txt -covermode=atomic
+  - make test-unit test-integration
 after_success:
+  - go test -coverprofile=coverage.txt -covermode=atomic
   - bash <(curl -s https://codecov.io/bash)

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -eu
 
 GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -5,16 +5,34 @@ GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 . "${GIT_ROOT}/bin/include/versioning"
 . "${GIT_ROOT}/.envrc"
 
-if [ -z ${TEST_NAMESPACE+x} ]; then
-  TEST_NAMESPACE="test$(date +%s)"
-  export TEST_NAMESPACE
 
-  remove_namespace() {
-    kubectl delete namespace --wait=false --grace-period=60 "$TEST_NAMESPACE"
-  }
-  trap remove_namespace EXIT
+PLATFORM="${PLATFORM:-linux}"
+ARCH="${ARCH:-amd64}"
 
-  kubectl create namespace "$TEST_NAMESPACE"
-fi
+KIND_PLATFORM="${KIND_PLATFORM:-${PLATFORM}-${ARCH}}"
+KIND_VERSION="${KIND_VERSION:-v0.6.0}"
+KUBECTL_VERSION="${KUBECTL_VERSION:-$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)}"
+
+tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
+clean() {
+  "${tmp_dir}"/kind delete cluster || true
+  rm -rf "${tmp_dir}"
+}
+trap clean EXIT
+
+export KUBECONFIG="${tmp_dir}/kubeconfig"
+
+echo "Downloading dependencies (kind $KIND_VERSION kubectl $KUBECTL_VERSION) in ${tmp_dir}"
+wget https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-${KIND_PLATFORM} -O "${tmp_dir}"/kind
+wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/${PLATFORM}/${ARCH}/kubectl -O "${tmp_dir}"/kubectl
+chmod +x "${tmp_dir}"/kind
+chmod +x "${tmp_dir}"/kubectl
+
+"${tmp_dir}"/kind create cluster
+
+export PATH="${tmp_dir}:${PATH}"
+
+# Wait for SA to be ready
+n=0; until ((n >= 60)); do kubectl -n default get serviceaccount default -o name && break; n=$((n + 1)); sleep 1; done; ((n < 60))
 
 ginkgo --slowSpecThreshold=50 integration/

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -15,24 +15,30 @@ KUBECTL_VERSION="${KUBECTL_VERSION:-$(curl -s https://storage.googleapis.com/kub
 
 tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
 clean() {
-  "${tmp_dir}"/kind delete cluster || true
+  "${tmp_dir}"/kind delete cluster --name=eirinix-integration-tests || true
   rm -rf "${tmp_dir}"
 }
 trap clean EXIT
 
 export KUBECONFIG="${tmp_dir}/kubeconfig"
 
-echo "Downloading dependencies (kind $KIND_VERSION kubectl $KUBECTL_VERSION) in ${tmp_dir}"
+echo "Downloading dependencies (kind $KIND_VERSION kubectl $KUBECTL_VERSION) in ${tmp_dir} and starting kind"
+{
 wget https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-${KIND_PLATFORM} -O "${tmp_dir}"/kind
 wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/${PLATFORM}/${ARCH}/kubectl -O "${tmp_dir}"/kubectl
 chmod +x "${tmp_dir}"/kind
 chmod +x "${tmp_dir}"/kubectl
 
-"${tmp_dir}"/kind create cluster
+"${tmp_dir}"/kind create cluster --name=eirinix-integration-tests
+} &> /dev/null
 
 export PATH="${tmp_dir}:${PATH}"
 
+echo "Waiting for the cluster to be ready"
+
 # Wait for SA to be ready
+{
 n=0; until ((n >= 60)); do kubectl -n default get serviceaccount default -o name && break; n=$((n + 1)); sleep 1; done; ((n < 60))
+} &> /dev/null
 
 ginkgo --slowSpecThreshold=50 integration/

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/martian v2.1.0+incompatible
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.6.0
+	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,7 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -200,6 +201,8 @@ github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtP
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -1,0 +1,13 @@
+package integration_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestExtensions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, `Extensions API Suite (integration tests)`)
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1,0 +1,86 @@
+package integration_test
+
+import (
+	//. "github.com/SUSE/eirinix"
+
+	"fmt"
+	"time"
+
+	catalog "github.com/SUSE/eirinix/testing"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("EiriniX", func() {
+	Context("With a fake pod", func() {
+		c := catalog.NewCatalog()
+		It("Without an EiriniX extension running, it has only one environment variable", func() {
+			app, err := c.StartEiriniApp()
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				runs, err := app.IsRunning()
+				Expect(err).ToNot(HaveOccurred())
+
+				return runs
+			}, time.Duration(60*time.Second), time.Duration(5*time.Second)).Should(BeTrue())
+
+			err = app.Sync()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(app.Pod.Spec.Containers)).To(Equal(1))
+			Expect(len(app.Pod.Spec.Containers[0].Envs)).To(Equal(1))
+			Expect(app.Pod.Spec.Containers[0].Envs).Should(ContainElement(catalog.ContainerEnv{Name: "FAKE_APP", Value: "fake content"}))
+			Expect(app.Delete()).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("With a simple extension running", func() {
+		It("Starts, register the extension which injects a variable into the pod definition", func() {
+			c := catalog.NewCatalog()
+			m := c.IntegrationManager()
+			e := &catalog.EditEnvExtension{}
+
+			err := c.RegisterEiriniXService()
+			Expect(err).ToNot(HaveOccurred())
+
+			m.AddExtension(e)
+			go m.Start()   // we should first check registration is ok etc. But we need to setup services first
+			defer m.Stop() // Stop the extension when the test finishes
+			//defer catalog.KubeClean()
+
+			// At some point the extension should register
+			Eventually(func() string {
+				str, err := catalog.Kubectl([]string{}, "get", "mutatingwebhookconfiguration")
+				fmt.Println(str)
+				Expect(err).ToNot(HaveOccurred())
+
+				return str
+			}, time.Duration(60*time.Second), time.Duration(5*time.Second)).ShouldNot(ContainSubstring("No resources found in default namespace"))
+
+			app, err := c.StartEiriniApp()
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				runs, err := app.IsRunning()
+				Expect(err).ToNot(HaveOccurred())
+
+				return runs
+			}, time.Duration(60*time.Second), time.Duration(5*time.Second)).Should(BeTrue())
+
+			err = app.Sync()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(app.Pod.Spec.Containers)).To(Equal(1))
+			Expect(len(app.Pod.Spec.Containers[0].Envs)).To(Equal(2))
+			Expect(app.Pod.Spec.Containers[0].Envs).Should(ContainElement(catalog.ContainerEnv{Name: "STICKY_MESSAGE", Value: "Eirinix is awesome!"}))
+			Expect(app.Pod.Spec.Containers[0].Envs).Should(ContainElement(catalog.ContainerEnv{Name: "FAKE_APP", Value: "fake content"}))
+			Expect(app.Delete()).ToNot(HaveOccurred())
+
+			err = catalog.KubeClean()
+			Expect(err).ToNot(HaveOccurred())
+
+			str, err := catalog.Kubectl([]string{}, "get", "mutatingwebhookconfiguration")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(str).To(ContainSubstring("No resources found in default namespace"))
+		})
+	})
+})

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 var _ = Describe("EiriniX", func() {
-	Context("With a fake pod", func() {
+	Context("without an EiriniX extension running", func() {
 		c := catalog.NewCatalog()
-		It("Without an EiriniX extension running, it has only one environment variable", func() {
+		It("has only one environment variable", func() {
 			app, err := c.StartEiriniApp()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -34,7 +34,7 @@ var _ = Describe("EiriniX", func() {
 	})
 
 	Context("With a simple extension running", func() {
-		It("Starts, register the extension which injects a variable into the pod definition", func() {
+		It("injects a variable into the pod definition", func() {
 			c := catalog.NewCatalog()
 			m := c.IntegrationManager()
 			e := &catalog.EditEnvExtension{}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3,7 +3,6 @@ package integration_test
 import (
 	//. "github.com/SUSE/eirinix"
 
-	"fmt"
 	"time"
 
 	catalog "github.com/SUSE/eirinix/testing"
@@ -51,7 +50,6 @@ var _ = Describe("EiriniX", func() {
 			// At some point the extension should register
 			Eventually(func() string {
 				str, err := catalog.Kubectl([]string{}, "get", "mutatingwebhookconfiguration")
-				fmt.Println(str)
 				Expect(err).ToNot(HaveOccurred())
 
 				return str

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -44,7 +44,7 @@ var _ = Describe("EiriniX", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			m.AddExtension(e)
-			go m.Start()   // we should first check registration is ok etc. But we need to setup services first
+			go m.Start()
 			defer m.Stop() // Stop the extension when the test finishes
 			//defer catalog.KubeClean()
 
@@ -81,6 +81,57 @@ var _ = Describe("EiriniX", func() {
 			str, err := catalog.Kubectl([]string{}, "get", "mutatingwebhookconfiguration")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(str).To(ContainSubstring("No resources found in default namespace"))
+		})
+	})
+
+	Context("With a simple extension running", func() {
+		It("Register the extension", func() {
+			defer catalog.KubeClean() // Be sure to cleanup everything
+
+			// Check nothing is left
+			str, err := catalog.Kubectl([]string{}, "get", "mutatingwebhookconfiguration")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(str).To(ContainSubstring("No resources found in default namespace"))
+
+			c := catalog.NewCatalog()
+			m := c.IntegrationManager()
+			e := &catalog.EditEnvExtension{}
+
+			err = c.RegisterEiriniXService()
+			Expect(err).ToNot(HaveOccurred())
+
+			m.AddExtension(e)
+			err = m.RegisterExtensions()
+			Expect(err).ToNot(HaveOccurred())
+
+			str, err = catalog.Kubectl([]string{}, "get", "mutatingwebhookconfiguration")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(str).ToNot(ContainSubstring("No resources found in default namespace"))
+
+			m2 := c.IntegrationManagerNoRegister()
+			m2.AddExtension(e)
+			//	Expect(m2.Start()).ToNot(HaveOccurred())
+			go m2.Start()   // we should first check registration is ok etc. But we need to setup services first
+			defer m2.Stop() // Stop the extension when the test finishes
+			time.Sleep(time.Second * 60)
+			app, err := c.StartEiriniApp()
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				runs, err := app.IsRunning()
+				Expect(err).ToNot(HaveOccurred())
+
+				return runs
+			}, time.Duration(60*time.Second), time.Duration(5*time.Second)).Should(BeTrue())
+
+			err = app.Sync()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(app.Pod.Spec.Containers)).To(Equal(1))
+			Expect(len(app.Pod.Spec.Containers[0].Envs)).To(Equal(2))
+			Expect(app.Pod.Spec.Containers[0].Envs).Should(ContainElement(catalog.ContainerEnv{Name: "STICKY_MESSAGE", Value: "Eirinix is awesome!"}))
+			Expect(app.Pod.Spec.Containers[0].Envs).Should(ContainElement(catalog.ContainerEnv{Name: "FAKE_APP", Value: "fake content"}))
+			Expect(app.Delete()).ToNot(HaveOccurred())
+
 		})
 	})
 })

--- a/interface.go
+++ b/interface.go
@@ -107,4 +107,7 @@ type Manager interface {
 
 	// Register Extensions to the kubernetes cluster.
 	RegisterExtensions() error
+
+	// Stop stops the manager execution
+	Stop()
 }

--- a/manager.go
+++ b/manager.go
@@ -345,7 +345,7 @@ func (m *DefaultExtensionManager) SetKubeClient(c corev1client.CoreV1Interface) 
 	m.kubeClient = c
 }
 
-// RegisterExtensions it generates and register webhooks from the Extensions loaded in the Manager
+// RegisterExtensions generates the manager and the operator setup, and loads the extensions to the webhook server
 func (m *DefaultExtensionManager) RegisterExtensions() error {
 	if err := m.generateManager(); err != nil {
 		return err
@@ -360,6 +360,12 @@ func (m *DefaultExtensionManager) RegisterExtensions() error {
 	if err := AddToScheme(m.KubeManager.GetScheme()); err != nil {
 		return err
 	}
+
+	return m.LoadExtensions()
+}
+
+// LoadExtensions generates and register webhooks from the Extensions added to the Manager
+func (m *DefaultExtensionManager) LoadExtensions() error {
 
 	var webhooks []MutatingWebhook
 	for k, e := range m.Extensions {

--- a/manager.go
+++ b/manager.go
@@ -466,7 +466,7 @@ func (m *DefaultExtensionManager) Start() error {
 
 func (m *DefaultExtensionManager) Stop() {
 	defer m.Logger.Sync()
-	m.stopChannel <- struct{}{}
+	close(m.stopChannel)
 }
 
 func (o *ManagerOptions) getDefaultNamespaceLabel() string {

--- a/manager.go
+++ b/manager.go
@@ -8,16 +8,14 @@ import (
 	"strconv"
 	"time"
 
-	"go.uber.org/zap"
-
-	inmemorycredgen "code.cloudfoundry.org/cf-operator/pkg/credsgen/in_memory_generator"
-
 	"code.cloudfoundry.org/cf-operator/pkg/credsgen"
+	inmemorycredgen "code.cloudfoundry.org/cf-operator/pkg/credsgen/in_memory_generator"
 	kubeConfig "code.cloudfoundry.org/cf-operator/pkg/kube/config"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/config"
 	"github.com/SUSE/eirinix/util/ctxlog"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
+	"go.uber.org/zap"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -351,11 +349,10 @@ func (m *DefaultExtensionManager) RegisterExtensions() error {
 		return err
 	}
 
-	if m.Options.RegisterWebHook == nil || m.Options.RegisterWebHook != nil && *m.Options.RegisterWebHook {
-		if err := m.OperatorSetup(); err != nil {
-			return err
-		}
+	if err := m.OperatorSetup(); err != nil {
+		return err
 	}
+
 	// Setup Scheme for all resources
 	if err := AddToScheme(m.KubeManager.GetScheme()); err != nil {
 		return err

--- a/manager_test.go
+++ b/manager_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Extension Manager", func() {
 			err := eiriniManager.OperatorSetup()
 			Expect(err).ToNot(HaveOccurred())
 
-			err = eiriniManager.RegisterExtensions()
+			err = eiriniManager.LoadExtensions()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(eiriniManager.WebhookServer.CertDir).To(Equal(filepath.Join(os.TempDir(), eiriniManager.Options.SetupCertificateName)))
 			//	Expect(eiriniManager.WebhookServer.BootstrapOptions.MutatingWebhookConfigName).To(Equal("eirini-x-mutating-hook-default"))
@@ -149,7 +149,7 @@ var _ = Describe("Extension Manager", func() {
 		err := eiriniManager.OperatorSetup()
 		Expect(err).ToNot(HaveOccurred())
 
-		err = eiriniManager.RegisterExtensions()
+		err = eiriniManager.LoadExtensions()
 		Expect(err).ToNot(HaveOccurred())
 
 	})
@@ -184,7 +184,7 @@ var _ = Describe("Extension Manager", func() {
 		It("does not overwrite the existing secret", func() {
 			err := eiriniManager.OperatorSetup()
 			Expect(err).ToNot(HaveOccurred())
-			err = eiriniManager.RegisterExtensions()
+			err = eiriniManager.LoadExtensions()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(client.CreateCallCount()).To(Equal(1))                 // webhook config
 			Expect(generator.GenerateCertificateCallCount()).To(Equal(0)) // Generate CA and certificate
@@ -207,7 +207,7 @@ var _ = Describe("Extension Manager", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			eiriniManager.AddExtension(eirinixcatalog.SimpleExtension())
-			err = eiriniManager.RegisterExtensions()
+			err = eiriniManager.LoadExtensions()
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(Manager.ListExtensions()).ToNot(BeEmpty())
@@ -281,7 +281,7 @@ var _ = Describe("Extension Manager", func() {
 			eiriniServiceManager.AddExtension(eirinixcatalog.SimpleExtension())
 			err := eiriniServiceManager.OperatorSetup()
 			Expect(err).ToNot(HaveOccurred())
-			err = eiriniServiceManager.RegisterExtensions()
+			err = eiriniServiceManager.LoadExtensions()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(eiriniServiceManager.ListExtensions())).To(Equal(1))
 		})

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -67,6 +67,21 @@ func (c *Catalog) IntegrationManager() eirinix.Manager {
 		})
 }
 
+// IntegrationManagerNoRegister returns an Extensions manager which is used by integration tests, which doesn't register extensions again
+func (c *Catalog) IntegrationManagerNoRegister() eirinix.Manager {
+	RegisterWebhooks := false
+	return eirinix.NewManager(
+		eirinix.ManagerOptions{
+			Namespace:        "default",
+			Host:             c.KindHost,
+			Port:             c.ServicePort,
+			KubeConfig:       os.Getenv("KUBECONFIG"),
+			ServiceName:      "eirinix",
+			WebhookNamespace: "default",
+			RegisterWebHook:  &RegisterWebhooks,
+		})
+}
+
 // ServiceYaml returns the yaml of the endpoint + service used to reach eiriniX returned in IntegrationManager
 func (c *Catalog) ServiceYaml() []byte {
 	return []byte(`

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -5,15 +5,23 @@ package testing
 
 import (
 	"context"
+	"os"
+	"strconv"
 
 	operator_testing "code.cloudfoundry.org/cf-operator/testing"
 	eirinix "github.com/SUSE/eirinix"
+	"github.com/phayes/freeport"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
 // NewCatalog returns a Catalog, our helper for test cases
 func NewCatalog() Catalog {
-	return Catalog{Catalog: &operator_testing.Catalog{}}
+	port, err := freeport.GetFreePort()
+	if err != nil {
+		panic(err) // Cannot allocate free ports! everything will fail!
+	}
+	return Catalog{Catalog: &operator_testing.Catalog{}, ServicePort: int32(port), KindHost: "172.17.0.1"}
 }
 
 // NewContext returns a non-nil empty context, for usage when it is unclear
@@ -23,7 +31,11 @@ func NewContext() context.Context {
 }
 
 // Catalog provides several instances for test, based on the cf-operator's catalog
-type Catalog struct{ *operator_testing.Catalog }
+type Catalog struct {
+	*operator_testing.Catalog
+	ServicePort int32
+	KindHost    string
+}
 
 // SimpleExtension it's returning a fake dummy Eirini extension
 func (c *Catalog) SimpleExtension() eirinix.Extension {
@@ -40,6 +52,120 @@ func (c *Catalog) SimpleManager() eirinix.Manager {
 			Host:      "127.0.0.1",
 			Port:      90,
 		})
+}
+
+// IntegrationManager returns an Extensions manager which is used by integration tests
+func (c *Catalog) IntegrationManager() eirinix.Manager {
+	return eirinix.NewManager(
+		eirinix.ManagerOptions{
+			Namespace:        "default",
+			Host:             c.KindHost,
+			Port:             c.ServicePort,
+			KubeConfig:       os.Getenv("KUBECONFIG"),
+			ServiceName:      "eirinix",
+			WebhookNamespace: "default",
+		})
+}
+
+// ServiceYaml returns the yaml of the endpoint + service used to reach eiriniX returned in IntegrationManager
+func (c *Catalog) ServiceYaml() []byte {
+	return []byte(`
+apiVersion: v1
+kind: Service
+metadata:
+  name: eirinix
+spec:
+  ports:
+  - protocol: TCP
+    port: 443
+    targetPort: ` + strconv.Itoa(int(c.ServicePort)) + `
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: eirinix
+subsets:
+  - addresses:
+      - ip: ` + c.KindHost + `
+    ports:
+      - port: ` + strconv.Itoa(int(c.ServicePort)) + `
+`)
+}
+
+// EiriniAppYaml returns a fake Eirini app yaml
+func (c *Catalog) EiriniAppYaml() []byte {
+	return []byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: eirini-fake-app
+  labels:
+    ` + eirinix.LabelSourceType + `: APP
+spec:
+  containers:
+  - image: busybox:1.28.4
+    command:
+      - sleep
+      - "3600"
+    name: eirini-fake-app
+    env:
+    - name: FAKE_APP
+      value: "fake content"
+  restartPolicy: Always
+`)
+}
+
+// RegisterEiriniXService register the service generated in ServiceYaml()
+func (c *Catalog) RegisterEiriniXService() error {
+
+	err := KubeApply(c.ServiceYaml())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type EiriniApp struct {
+	Name string
+	Pod  *Pod
+}
+
+// StartEiriniApp starts EiriniAppYaml with kubernetes
+func (c *EiriniApp) IsRunning() (bool, error) {
+	p, err := KubePodStatus(c.Name)
+	if err != nil {
+		return false, err
+	}
+	return p.IsRunning(), nil
+}
+
+func (c *EiriniApp) Delete() error {
+	out, err := Kubectl([]string{}, "delete", "pod", c.Name)
+	if err != nil {
+		return errors.Wrap(err, "Failed: "+string(out))
+	}
+	return nil
+}
+
+func (c *EiriniApp) Sync() error {
+	p, err := KubePodStatus(c.Name)
+	if err != nil {
+		return err
+	}
+	c.Pod = p
+	return nil
+}
+
+// StartEiriniApp starts EiriniAppYaml with kubernetes
+func (c *Catalog) StartEiriniApp() (*EiriniApp, error) {
+
+	err := KubeApply(c.EiriniAppYaml())
+	if err != nil {
+		return nil, err
+	}
+
+	return &EiriniApp{Name: "eirini-fake-app"}, nil
 }
 
 // SimpleManagerService returns a dummy Extensions manager configured to run as a service

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -6,10 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
-
-	"strings"
 )
 
 func Kubectl(envs []string, args ...string) (string, error) {
@@ -84,7 +83,10 @@ func KubeClean() error {
 	if err != nil {
 		return errors.Wrap(err, "Failed: "+string(str))
 	}
-
+	str, err = Kubectl([]string{}, "delete", "svc", "--all")
+	if err != nil {
+		return errors.Wrap(err, "Failed: "+string(str))
+	}
 	return nil
 }
 func KubeApply(b []byte) error {

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -1,0 +1,107 @@
+package testing
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"strings"
+)
+
+func Kubectl(envs []string, args ...string) (string, error) {
+
+	k := exec.Command("kubectl", args...)
+	k.Env = os.Environ()
+	for _, e := range envs {
+		k.Env = append(k.Env, e)
+	}
+	out, err := k.CombinedOutput()
+	output := string(out)
+	output = strings.TrimSuffix(output, "\n")
+
+	if err != nil {
+		return output, err
+	}
+	return output, nil
+}
+
+type ContainerEnv struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+type Container struct {
+	Name string         `json:"name"`
+	Envs []ContainerEnv `json:"env"`
+}
+
+type PodStatus struct {
+	Phase string `json:"phase"`
+}
+type PodSpec struct {
+	Containers []Container `json:"containers"`
+}
+type Pod struct {
+	Spec      PodSpec   `json:"spec"`
+	PodStatus PodStatus `json:"status"`
+}
+
+func (p *Pod) IsRunning() bool {
+	if p.PodStatus.Phase == "Running" {
+		return true
+	}
+	return false
+}
+
+func KubePodStatus(podname string) (*Pod, error) {
+	str, err := Kubectl([]string{}, "get", "pod", podname, "-o", "json")
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed: "+string(str))
+	}
+
+	var p Pod
+	err = json.Unmarshal([]byte(str), &p)
+	if err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func KubeClean() error {
+	str, err := Kubectl([]string{}, "delete", "pod", "--all")
+	if err != nil {
+		return errors.Wrap(err, "Failed: "+string(str))
+	}
+	str, err = Kubectl([]string{}, "delete", "mutatingwebhookconfiguration", "--all")
+	if err != nil {
+		return errors.Wrap(err, "Failed: "+string(str))
+	}
+
+	str, err = Kubectl([]string{}, "delete", "secrets", "--all")
+	if err != nil {
+		return errors.Wrap(err, "Failed: "+string(str))
+	}
+
+	return nil
+}
+func KubeApply(b []byte) error {
+	tmpdir, err := ioutil.TempDir(os.TempDir(), "service")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpdir) // clean up
+	apply := filepath.Join(tmpdir, "apply.yaml")
+
+	err = ioutil.WriteFile(apply, b, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	out, err := Kubectl([]string{}, "apply", "-f", apply)
+	if err != nil {
+		return errors.Wrap(err, "Failed: "+string(out))
+	}
+	return nil
+}

--- a/webhook.go
+++ b/webhook.go
@@ -154,12 +154,10 @@ func (w *DefaultMutatingWebhook) RegisterAdmissionWebHook(server *webhook.Server
 		Handler: w,
 	}
 
-	if opts.ManagerOptions.RegisterWebHook == nil || opts.ManagerOptions.RegisterWebHook != nil && *opts.ManagerOptions.RegisterWebHook {
-		if server == nil {
-			return errors.New("The Mutating webhook needs a Webhook server to register to")
-		}
-		server.Register(w.Path, w.Webhook)
+	if server == nil {
+		return errors.New("The Mutating webhook needs a Webhook server to register to")
 	}
+	server.Register(w.Path, w.Webhook)
 	return nil
 }
 


### PR DESCRIPTION
This PR completes the work about splitting the registration stage of EiriniX - apparently there were some pending items, so every extension **now** can split and decide on their own when to register the mutating webhooks. It also includes fixes to issues found during the development. 

It also adds the integration test suite, which runs using kind , adding two simple test cases:

1) A simple extension which just injects an env var - it register and starts in one step (as it is now, default behavior)
2) The same extension is registered, and then later on started. It should still mutate the fake Eirini app pods.

Let's see now how travis/codecov likes it :) I think it should be also possible to account the integration tests into the coverage, I'll try to have a look