### PR TITLE
Allow to specify a starting RV for EiriniX watchers

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -110,4 +110,10 @@ type Manager interface {
 
 	// Stop stops the manager execution
 	Stop()
+
+	// SetManagerOptions it is a setter for the ManagerOptions
+	SetManagerOptions(ManagerOptions)
+
+	// GetManagerOptions returns current ManagerOptions
+	GetManagerOptions() ManagerOptions
 }

--- a/manager.go
+++ b/manager.go
@@ -18,8 +18,11 @@ import (
 	"go.uber.org/zap"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	fields "k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	machinerytypes "k8s.io/apimachinery/pkg/types"
@@ -131,6 +134,10 @@ type ManagerOptions struct {
 
 	// WebhookNamespace, when ServiceName is supplied, a WebhookNamespace is required to indicate in which namespace the webhook service runs on
 	WebhookNamespace string
+
+	// WatcherStartRV is the starting ResourceVersion of the PodList which is being watched (see Kubernetes #74022).
+	// If omitted, it will start watching from the current RV.
+	WatcherStartRV string
 }
 
 var addToSchemes = runtime.SchemeBuilder{}
@@ -236,7 +243,24 @@ func (m *DefaultExtensionManager) PatchFromPod(req admission.Request, pod *corev
 func (m *DefaultExtensionManager) GenWatcher(client corev1client.CoreV1Interface) (watch.Interface, error) {
 	podInterface := client.Pods(m.Options.Namespace)
 
-	return watchtools.NewRetryWatcher("1", &cache.ListWatch{
+	startResourceVersion := m.Options.WatcherStartRV
+
+	if startResourceVersion == "" {
+		lw := cache.NewListWatchFromClient(client.RESTClient(), "pods", v1.NamespaceAll, fields.Everything())
+		list, err := lw.List(metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		metaObj, err := meta.ListAccessor(list)
+		if err != nil {
+			return nil, err
+		}
+
+		startResourceVersion = metaObj.GetResourceVersion()
+	}
+
+	return watchtools.NewRetryWatcher(startResourceVersion, &cache.ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			options.Watch = true
 
@@ -438,8 +462,7 @@ func (m *DefaultExtensionManager) HandleEvent(e watch.Event) {
 	}
 }
 
-// ReadWatcherEvent tries to read events from the watcher channel and return error if the channel
-// is closed. It should be run in a loop.
+// ReadWatcherEvent tries to read events from the watcher channel. It should be run in a loop.
 func (m *DefaultExtensionManager) ReadWatcherEvent(w watch.Interface) {
 	resultChannel := w.ResultChan()
 

--- a/manager.go
+++ b/manager.go
@@ -277,6 +277,11 @@ func (m *DefaultExtensionManager) GetLogger() *zap.SugaredLogger {
 	return m.Logger
 }
 
+// GetManagerOptions returns the Manager options
+func (m *DefaultExtensionManager) GetManagerOptions() ManagerOptions {
+	return m.Options
+}
+
 func (m *DefaultExtensionManager) kubeSetup() error {
 	restConfig, err := kubeConfig.NewGetter(m.Logger).Get(m.Options.KubeConfig)
 	if err != nil {
@@ -383,6 +388,11 @@ func (m *DefaultExtensionManager) SetKubeConnection(c *rest.Config) {
 // SetKubeClient sets a kube client corev1 from a given one
 func (m *DefaultExtensionManager) SetKubeClient(c corev1client.CoreV1Interface) {
 	m.kubeClient = c
+}
+
+// SetManagerOptions sets the ManagerOptions with the provided one
+func (m *DefaultExtensionManager) SetManagerOptions(o ManagerOptions) {
+	m.Options = o
 }
 
 // RegisterExtensions generates the manager and the operator setup, and loads the extensions to the webhook server

--- a/manager_test.go
+++ b/manager_test.go
@@ -75,6 +75,7 @@ var _ = Describe("Extension Manager", func() {
 		eiriniManager.KubeManager = manager
 		eiriniManager.Options.Namespace = "default"
 		eiriniManager.Credsgen = generator
+		eiriniManager.Options.WatcherStartRV = "1"
 
 		eiriniServiceManager.Context = ctx
 		eiriniServiceManager.KubeManager = manager

--- a/manager_test.go
+++ b/manager_test.go
@@ -85,21 +85,23 @@ var _ = Describe("Extension Manager", func() {
 
 	Context("DefaultExtensionManager", func() {
 		It("satisfies the Manager interface", func() {
-			m, ok := Manager.(*DefaultExtensionManager)
-			Expect(ok).To(Equal(true))
-			Expect(m.Options.Namespace).To(Equal("default"))
-			Expect(m.Options.Host).To(Equal("127.0.0.1"))
-			Expect(m.Options.Port).To(Equal(int32(90)))
+			Expect(Manager.GetManagerOptions().Namespace).To(Equal("default"))
+			Expect(Manager.GetManagerOptions().Host).To(Equal("127.0.0.1"))
+			Expect(Manager.GetManagerOptions().Port).To(Equal(int32(90)))
 			defaultPolicy := admissionregistrationv1beta1.Fail
-			Expect(m.Options.FailurePolicy).To(Equal(&defaultPolicy))
-			Expect(m.Options.OperatorFingerprint).To(Equal("eirini-x"))
-			Expect(m.Options.KubeConfig).To(Equal(""))
-			Expect(m.Options.Logger).NotTo(Equal(nil))
-			Expect(m.Logger).NotTo(Equal(nil))
-			Expect(*m.Options.FilterEiriniApps).To(BeTrue())
-
+			Expect(Manager.GetManagerOptions().FailurePolicy).To(Equal(&defaultPolicy))
+			Expect(Manager.GetManagerOptions().OperatorFingerprint).To(Equal("eirini-x"))
+			Expect(Manager.GetManagerOptions().KubeConfig).To(Equal(""))
+			Expect(Manager.GetManagerOptions().Logger).NotTo(Equal(nil))
+			Expect(*Manager.GetManagerOptions().FilterEiriniApps).To(BeTrue())
 			Expect(Manager.GetLogger()).ToNot(BeNil())
 			Expect(Manager.ListExtensions()).To(BeEmpty())
+		})
+		It("provides option setter", func() {
+			o := Manager.GetManagerOptions()
+			o.Namespace = "test"
+			Manager.SetManagerOptions(o)
+			Expect(Manager.GetManagerOptions().Namespace).To(Equal("test"))
 		})
 		It("Setups correctly the operator structures", func() {
 			err := eiriniManager.OperatorSetup()


### PR DESCRIPTION
It deals with the Kubernetes issue #74022, by starting the watcher
RV by default to the current one. Allows to override the mechanism
by specifying a start RV number.